### PR TITLE
Taka/fix routing

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 const { sourceFileArray } = require('./post/summary.json');
 
 function sourceFileNameToUrl(filePath){
-  const deleteExt = filePath.replace('.md', 'index');
+  const deleteExt = filePath.replace('.md', '').filePathre.replace('markdown','');;
   const fileName = deleteExt.split('/')[deleteExt.split('/').length - 1];
   const splitArray = fileName.split('-');
   return `/post/${splitArray.slice(0, 3).join('-')}/${splitArray.slice(3).join('-')}`;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 const { sourceFileArray } = require('./post/summary.json');
 
 function sourceFileNameToUrl(filePath){
-  const deleteExt = filePath.replace('.md', '').filePathre.replace('markdown','');
+  const deleteExt = filePath.replace('.md', '').replace('markdown','');
   const fileName = deleteExt.split('/')[deleteExt.split('/').length - 1];
   const splitArray = fileName.split('-');
   return `/post/${splitArray.slice(0, 3).join('-')}/${splitArray.slice(3).join('-')}`;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 const { sourceFileArray } = require('./post/summary.json');
 
 function sourceFileNameToUrl(filePath){
-  const deleteExt = filePath.replace('.md', '').filePathre.replace('markdown','');;
+  const deleteExt = filePath.replace('.md', '').filePathre.replace('markdown','');
   const fileName = deleteExt.split('/')[deleteExt.split('/').length - 1];
   const splitArray = fileName.split('-');
   return `/post/${splitArray.slice(0, 3).join('-')}/${splitArray.slice(3).join('-')}`;


### PR DESCRIPTION
const deleteExt = filePath.replace('.md', '').replace('markdown','');

変更点:
replace('markdown','');を追加

理由: 
post/markdown/2019-9-20-vue1.mdという形式で保存されているsummaryファイルをルーティングに利用しているが、これをパースをする際にpost/2019-9-20-vue1となるはずが、post/markdown/2019-9-20-vue1となってるため、正常なリロードやリンクの直アクセスができなかったのでmarkdownもパースするように変更を行った。